### PR TITLE
Http server interface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # this is improper - we need to start using tags in GitHub properly
-version=0.5
+version=0.1
 
 buildtime=$(date)
 branch=$(git rev-parse --abbrev-ref HEAD)

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+[server]
+address = ":8080"
+api_prefix = "/api/v1/"
+api_spec_file = "openapi.json"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/RedHatInsights/insights-results-smart-proxy
 
 go 1.13
+
+require (
+	github.com/gorilla/mux v1.7.4
+	github.com/rs/zerolog v1.18.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
+github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// Configuration represents configuration of REST API HTTP server
+type Configuration struct {
+	Address     string `mapstructure:"address" toml:"address"`
+	APIPrefix   string `mapstructure:"api_prefix" toml:"api_prefix"`
+	APISpecFile string `mapstructure:"api_spec_file" toml:"api_spec_file"`
+	Debug       bool   `mapstructure:"debug" toml:"debug"`
+	UseHTTPS    bool   `mapstructure:"use_https" toml:"use_https"`
+	EnableCORS  bool   `mapstructure:"enable_cors" toml:"enable_cors"`
+}

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	// MainEndpoint defines suffix of the root endpoint
+	MainEndpoint = ""
+)
+
+// MakeURLToEndpoint creates URL to endpoint, use constants from file endpoints.go
+func MakeURLToEndpoint(apiPrefix, endpoint string, args ...interface{}) string {
+	re := regexp.MustCompile(`\{[a-zA-Z_0-9]+\}`)
+	endpoint = re.ReplaceAllString(endpoint, "%v")
+	return apiPrefix + fmt.Sprintf(endpoint, args...)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package server contains implementation of REST API server (HTTPServer) for the
+// Insights Results Smart Proxy.
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// HTTPServer contains the configuration and objects to handle a HTTP server
+type MyHTTPServer struct {
+	Config Configuration
+	Serv   *http.Server
+}
+
+// New constructs new implementation of MyHTTPServer
+func New(conf Configuration) HTTPServer {
+	return &MyHTTPServer{
+		Config: conf,
+	}
+}
+
+func (server *MyHTTPServer) AddEndpointsToRouter(router *mux.Router) {
+	fmt.Println("Configuring endpoints")
+	// apiPrefix := server.Config.APIPrefix
+	// openAPIURL := apiPrefix + filepath.Base(server.Config.APISpecFile)
+
+	// common REST API endpoints
+	// router.HandleFunc(apiPrefix+MainEndpoint, server.mainEndpoint).Methods(http.MethodGet)
+
+	// OpenAPI specs
+	// router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
+}
+
+func (server *MyHTTPServer) GetConfiguration() Configuration {
+	return server.Config
+}
+
+func (server *MyHTTPServer) GetServ() *http.Server {
+	return server.Serv
+}
+
+func (server *MyHTTPServer) SetServ(httpServer *http.Server) {
+	server.Serv = httpServer
+}

--- a/server/server_iface.go
+++ b/server/server_iface.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+)
+
+type HTTPServer interface {
+	GetConfiguration() Configuration
+	SetServ(*http.Server)
+	GetServ() *http.Server
+	AddEndpointsToRouter(*mux.Router)
+}
+
+type HTTPServerImpl struct{}
+
+// Start starts the server
+func Start(server HTTPServer) error {
+	address := server.GetConfiguration().Address
+	log.Info().Msgf("Starting HTTP server at '%s'", address)
+	router := initialize(server, address)
+	httpServer := &http.Server{Addr: address, Handler: router}
+	var err error
+
+	if server.GetConfiguration().UseHTTPS {
+		err = httpServer.ListenAndServeTLS("server.crt", "server.key")
+	} else {
+		err = httpServer.ListenAndServe()
+	}
+	if err != nil && err != http.ErrServerClosed {
+		log.Error().Err(err).Msg("Unable to start HTTP/S server")
+		return err
+	}
+
+	server.SetServ(httpServer)
+
+	return nil
+}
+
+// Stop stops server's execution
+func Stop(server HTTPServer, ctx context.Context) error {
+	httpServer := server.GetServ()
+	return httpServer.Shutdown(ctx)
+}
+
+// initialize perform the server initialization
+func initialize(server HTTPServer, address string) http.Handler {
+	log.Info().Msgf("Initializing HTTP server at '%s'", address)
+
+	router := mux.NewRouter().StrictSlash(true)
+	server.AddEndpointsToRouter(router)
+
+	return router
+}

--- a/smart_proxy.go
+++ b/smart_proxy.go
@@ -17,5 +17,29 @@ limitations under the License.
 // Entry point to the insights results smart proxy
 package main
 
+import (
+	"os"
+	"strings"
+)
+
+// ExitStatusOK means that the tool finished with success
+const ExitStatusOK = iota
+
+func handleCommand(command string) int {
+	switch command {
+	case "start-service":
+		return ExitStatusOK
+	}
+
+	return ExitStatusOK
+}
+
 func main() {
+	command := "start-service"
+
+	if len(os.Args) >= 2 {
+		command = strings.ToLower(strings.TrimSpace(os.Args[1]))
+	}
+
+	os.Exit(handleCommand(command))
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Versioning information
+package main
+
+import (
+	"fmt"
+)
+
+var (
+	// BuildVersion contains the major.minor version of the CLI client
+	BuildVersion string = "*not set*"
+
+	// BuildTime contains timestamp when the CLI client has been built
+	BuildTime string = "*not set*"
+
+	// BuildBranch contains Git branch used to build this application
+	BuildBranch string = "*not set*"
+
+	// BuildCommit contains Git commit used to build this application
+	BuildCommit string = "*not set*"
+)
+
+func printInfo(msg string, val string) {
+	fmt.Printf("%s\t%s\n", msg, val)
+}
+
+func printVersionInfo() {
+	printInfo("Version:", BuildVersion)
+	printInfo("Build time:", BuildTime)
+	printInfo("Branch:", BuildBranch)
+	printInfo("Commit:", BuildCommit)
+}


### PR DESCRIPTION
Proposal about extracting the common HTTP Server to a common place to be reused by aggregator, content service and smart proxy.

Take a look inside `server/server_iface.go`. This file and the `server/configuration.go\ should be in a different package and probably in a different repository.

A new server implementation just need to define its own attributes (at least configuration and an `http.Server`).

Depending on the configuration, the methods in the package will call to the AddEndpoints and AddDebugEndpoints, which are basically the differences between our 3 services.

This implementation is not finished. It lacks on configuring authentication and CORS headers

WDYT?